### PR TITLE
added --verbose, --overwrite flags, changed word use of tan to skew as it more accurately reflects the underlying math, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # About Gskewer
-Gskewer is a tool to skew transform gcode file coordinates to account for axis misalignment of a 3D printer.
+Gskewer is a tool to skew transform gcode file coordinates to account for axis misalignment and scale misconfiguration of a 3D printer.
 
 In order to use Gskewer you will need to print a test cube, take accurate measurements of the cube, then input those measurements as arguments for Gskewer. You can also use Calilantern or Califlower, and use the SKEW_FACTORs generated for Marlin or RepRap firmwares.
 
@@ -63,6 +63,12 @@ Gskewer will automatically generate a new gcode file with "-gskewer-xz0.0,xz0.0,
 
 `--xzskew`
 	The skew factor, aka error in the XZ pair (xzerr/xzlen).
+
+`--xscale`
+    Shrink or expand X axis. This is optional, default value is 100.0
+
+`--yscale`
+    Shrink or expand Y axis. This is optional, default value is 100.0
 
 `--overwrite`
     Overwrite the input file with the skewed version. Useful for slicer post-processing.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # About Gskewer
 Gskewer is a tool to skew transform gcode file coordinates to account for axis misalignment of a 3D printer.
 
-In order to use Gskewer you will need to print a test cube, take accurate measurements of the cube, then input those measurements as arguments for Gskewer. 
+In order to use Gskewer you will need to print a test cube, take accurate measurements of the cube, then input those measurements as arguments for Gskewer. You can also use Calilantern or Califlower, and use the SKEW_FACTORs generated for Marlin or RepRap firmwares.
 
 The G-code file to be modified, the measured error (in mm), and the distance from zero where the measurement was taken is then entered into skew.py before being run.
+
+This can be added as a slicer post-processing script.
 
 
 # Preparing to use Gskewer
@@ -16,11 +18,11 @@ The general idea of the measurements required and which arguments they correspon
 ![MechanizedMedic](https://github.com/MechanizedMedic/gskewer/raw/master/gskewer_measuring1.png "Positive skew error.")
 ![MechanizedMedic](https://github.com/MechanizedMedic/gskewer/raw/master/gskewer_measuring2.png "Negative skew error.")
 
-These measurements are to be taken for each of the three axis pairs of the cube: XY, YZ, and ZX.
+These measurements are to be taken for each of the three axis pairs of the cube: XY, YZ, and xz.
 
-You will end up with six measurements/arguments: xylen, xyerr, yzlen, yzerr, zxlen, and zxerr.
+You will end up with six measurements/arguments: xylen, xyerr, yzlen, yzerr, xzlen, and xzerr.
 
-The initial six measurements can be simplified to a tangent argument by dividing the error by length. (ie: xyerr/xylen=xytan) The three tangent arguments are: xytan, yztan, and zxtan.
+The initial six measurements can be simplified to a skew argument by dividing the error by length (ie: xyerr/xylen=xyskew). The skew arguments are: xyskew, yzskew, and xzskew.
 
 
 # Using Gskewer
@@ -30,34 +32,40 @@ Gskewer will automatically generate a new gcode file with "-skewed" added to the
 
 ### Examples
 
-`gskewer --xyerr 1.2 --xylen 80 Cube80mm.gcode` will adjust the X coordinate proportionally by -1.2 mm for every 80mm in the Y coordinate. Also, only the XY plane is affected as other arguements are not used. The output file will be "Cube80mm-skewed.gcode".
+`gskewer --xyerr 1.2 --xylen 80 --yzskew 0 --xzskew 0 Cube80mm.gcode` will adjust the X coordinate proportionally by -1.2 mm for every 80mm in the Y coordinate. The output file will be "Cube80mm-skewed.gcode".
 
-`gskewer --xytan 0.015 Cube80mm.gcode` is equivalent to the example above, as `xytan = xyerr / xylen`.
+`--xyskew 0.015` is equivalent in the example above, as `xyskew = xyerr / xylen`. The skew factors are 
 
 ### Gskewer Arguments
 `--xyerr`
-	Error in the X-axis for the XY pair in mm. (This argument cannot be used with "xytan")
+	Error in the X-axis for the XY pair in mm. (This argument cannot be used with "xyskew")
 
 `--xylen`
 	Length of the test cube side where the "xyerr" measurement was taken.
 
-`--xytan`
-	The error in the ZX pair as a tangent. (zxerr/zxlen)
+`--xyskew`
+	The skew factor, aka error in the XY pair (xyerr/xylen)
 
 `--yzerr`
-	Error in the Y-axis for the YZ pair in mm. (This argument cannot be used with "yztan")
+	Error in the Y-axis for the YZ pair in mm. (This argument cannot be used with "yzskew")
 
 `--yzlen`
 	Length of the test cube side where the "yzerr" measurement was taken.
 
-`--yztan`
-	The error in the YZ pair as a tangent. (yzerr/yzlen)
+`--yzskew`
+	The skew factor, aka error in the YZ pair (yzerr/yzlen).
 
-`--zxerr`
-	Error in the Z-axis for the ZX pair in mm. (This argument cannot be used with "zxtan")
+`--xzerr`
+	Error in the Z-axis for the XZ pair in mm. (This argument cannot be used with "xzskew")
 
-`--zxlen`
-	Length of the test cube side where the "zxerr" measurement was taken.
+`--xzlen`
+	Length of the test cube side where the "xzerr" measurement was taken.
 
-`--zxtan`
-	The error in the ZX pair as a tangent. (zxerr/zxlen)
+`--xzskew`
+	The skew factor, aka error in the XZ pair (xzerr/xzlen).
+
+`--overwrite`
+    Overwrite the input file with the skewed version. Useful for slicer post-processing.
+
+`--verbose`
+    Increases terminal output verbosity.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The initial six measurements can be simplified to a skew argument by dividing th
 # Using Gskewer
 `gskewer [arguements] file`
 
-Gskewer will automatically generate a new gcode file with "-skewed" added to the file name. If the output file name already exists gskewer will delete the existing file and write a new one.
+Gskewer will automatically generate a new gcode file with "-gskewer-xz0.0,xz0.0,yz0.0" added to the file name (with the actual values appended). If the output file name already exists gskewer will overwrite the existing file. If --overwrite is specified, the *original* file will be replaced.
 
 ### Examples
 

--- a/skew.py
+++ b/skew.py
@@ -29,20 +29,20 @@ yzgroup.add_argument(
 yzgroup.add_argument(
     '--yzskew',
     type=float,
-    help='The skew factor, aka error in the yz pair (yzerr/yzlen).'
+    help='The skew factor, aka error in the YZ pair (yzerr/yzlen).'
 )
 
 
-zxgroup = parser.add_mutually_exclusive_group(required=True)
-zxgroup.add_argument(
-    '--zxerr',
+xzgroup = parser.add_mutually_exclusive_group(required=True)
+xzgroup.add_argument(
+    '--xzerr',
     type=float,
-    help='Error in the Z-axis for the ZX pair in mm.'
+    help='Error in the Z-axis for the XZ pair in mm.'
 )
-zxgroup.add_argument(
-    '--zxskew',
+xzgroup.add_argument(
+    '--xzskew',
     type=float,
-    help='The skew factor, aka error in the ZX pair (zxerr/zxlen).'
+    help='The skew factor, aka error in the XZ pair (xzerr/xzlen).'
 )
 
 
@@ -59,10 +59,10 @@ parser.add_argument(
     help='Length of the side where the YZ error measurement was taken. This is optional, default value is 100mm'
 )
 parser.add_argument(
-    '--zxlen',
+    '--xzlen',
     default=100,
     type=int,
-    help='Length of the side where the ZX error measurement was taken. This is optional, default value is 100mm'
+    help='Length of the side where the XZ error measurement was taken. This is optional, default value is 100mm'
 )
 
 # input file setup. name of input file is not in "args.file"
@@ -92,7 +92,17 @@ else:
     xyskew = 0.0
 
 if not xyskew == 0:
-    print('The XY error is set to', xyskew)
+    print('The XY skew is set to', xyskew)
+
+if args.xzskew:
+    xzskew = args.xzskew
+elif args.xzerr:
+    xzskew = args.xzerr / args.xzlen
+else:
+    xzskew = 0.0
+
+if not xzskew == 0:
+    print('The XZ skew is set to', xzskew)
 
 if args.yzskew:
     yzskew = args.yzskew
@@ -102,20 +112,12 @@ else:
     yzskew = 0.0
 
 if not yzskew == 0:
-    print('The YZ error is set to', yzskew)
+    print('The YZ skew is set to', yzskew)
 
-if args.zxskew:
-    zxskew = args.zxskew
-elif args.zxerr:
-    zxskew = args.zxerr / args.zxlen
-else:
-    zxskew = 0.0
 
-if not zxskew == 0:
-    print('The ZX error is set to', zxskew)
-
-if xyskew == 0.0 and yzskew == 0.0 and zxskew == 0.0:
+if xyskew == 0.0 and yzskew == 0.0 and xzskew == 0.0:
     print('No skew parameters provided. Nothing will be done.')
+    exit(0)
 
 filename = args.file
 
@@ -158,7 +160,7 @@ with open(outname, 'a') as outfile:
                 # calculate the corrected/skewed XYZ coordinates
                 xout = round(xin - yin * xyskew, 3)
                 yout = round(yin - zin * yzskew, 3)
-                xout = round(xout - zin * zxskew, 3)
+                xout = round(xout - zin * xzskew, 3)
                 # Z coodinates must remain the same to prevent layers being tilted!
                 zout = zin
 

--- a/skew.py
+++ b/skew.py
@@ -69,6 +69,13 @@ parser.add_argument(
 parser.add_argument("file", type=str)
 
 parser.add_argument(
+    '-o',
+    '--overwrite',
+    action='store_true',
+    help='Overwrite the input file with the skewed version. Useful for slicer post-processing.'
+)
+
+parser.add_argument(
     '-v',
     '--verbose',
     action='count',
@@ -121,58 +128,60 @@ zin = 0.0
 if os.path.isfile(outname):
     os.remove(outname)
 
-outfile = open(outname, 'a')
+with open(outname, 'a') as outfile:
+    with open(filename, 'r') as infile:
+        for line in infile:
+            # Check that the current 'line' is a move, if so the line is processed
+            gmatch = re.match(r'G[0-1]', line, re.I)
+            if gmatch:
+                if args.verbose:
+                    print('line was a G0/G1 command!')
 
-with open(filename, 'r') as infile:
-    for line in infile:
-        # Check that the current 'line' is a move, if so the line is processed
-        gmatch = re.match(r'G[0-1]', line, re.I)
-        if gmatch:
-            if args.verbose:
-                print('line was a G0/G1 command!')
+                # load the incoming X coordinate into a variable. Previous value will be used if new value is not found.
+                xsrch = re.search(r'[xX]-?\d*\.*\d*', line, re.I)
+                if xsrch:  # if an X value is found
+                    # Strip the letter from the coordinate.
+                    xin = float(re.sub(r'[xX]', '', xsrch.group()))
 
-            # load the incoming X coordinate into a variable. Previous value will be used if new value is not found.
-            xsrch = re.search(r'[xX]-?\d*\.*\d*', line, re.I)
-            if xsrch:  # if an X value is found
-                # Strip the letter from the coordinate.
-                xin = float(re.sub(r'[xX]', '', xsrch.group()))
+                # load the incoming Y coordinate into a variable. Previous value will be used if new value is not found.
+                ysrch = re.search(r'[yY]-?\d*\.*\d*', line, re.I)
+                if ysrch:
+                    # Strip the letter from the coordinate.
+                    yin = float(re.sub(r'[yY]', '', ysrch.group()))
 
-            # load the incoming Y coordinate into a variable. Previous value will be used if new value is not found.
-            ysrch = re.search(r'[yY]-?\d*\.*\d*', line, re.I)
-            if ysrch:
-                # Strip the letter from the coordinate.
-                yin = float(re.sub(r'[yY]', '', ysrch.group()))
+                # load the incoming Z coordinate into a variable. Previous value will be used if new value is not found.
+                zsrch = re.search(r'[zZ]-?\d*\.*\d*', line, re.I)
+                if zsrch:
+                    # Strip the letter from the coordinate.
+                    zin = float(re.sub(r'[zZ]', '', zsrch.group()))
 
-            # load the incoming Z coordinate into a variable. Previous value will be used if new value is not found.
-            zsrch = re.search(r'[zZ]-?\d*\.*\d*', line, re.I)
-            if zsrch:
-                # Strip the letter from the coordinate.
-                zin = float(re.sub(r'[zZ]', '', zsrch.group()))
+                # calculate the corrected/skewed XYZ coordinates
+                xout = round(xin - yin * xytan, 3)
+                yout = round(yin - zin * yztan, 3)
+                xout = round(xout - zin * zxtan, 3)
+                # Z coodinates must remain the same to prevent layers being tilted!
+                zout = zin
 
-            # calculate the corrected/skewed XYZ coordinates
-            xout = round(xin - yin * xytan, 3)
-            yout = round(yin - zin * yztan, 3)
-            xout = round(xout - zin * zxtan, 3)
-            # Z coodinates must remain the same to prevent layers being tilted!
-            zout = zin
+                lineout = line
+                if args.verbose:
+                    print('old line:', lineout)
 
-            lineout = line
-            if args.verbose:
-                print('old line:', lineout)
+                if xsrch:
+                    lineout = re.sub(r'[xX]-?\d*\.*\d*', 'X' + str(xout), lineout)
 
-            if xsrch:
-                lineout = re.sub(r'[xX]-?\d*\.*\d*', 'X' + str(xout), lineout)
+                if ysrch:
+                    lineout = re.sub(r'[yY]-?\d*\.*\d*', 'Y' + str(yout), lineout)
 
-            if ysrch:
-                lineout = re.sub(r'[yY]-?\d*\.*\d*', 'Y' + str(yout), lineout)
+                if zsrch:
+                    lineout = re.sub(r'[zZ]-?\d*\.*\d*', 'Z' + str(zout), lineout)
 
-            if zsrch:
-                lineout = re.sub(r'[zZ]-?\d*\.*\d*', 'Z' + str(zout), lineout)
+                if args.verbose:
+                    print('new line: ', lineout)
+                outfile.write(lineout)
+            else:
+                if args.verbose:
+                    print('Skipping, not a movement.', line)
+                outfile.write(line)
 
-            if args.verbose:
-                print('new line: ', lineout)
-            outfile.write(lineout)
-        else:
-            if args.verbose:
-                print('Skipping, not a movement.', line)
-            outfile.write(line)
+if args.overwrite:
+    os.replace(outname, filename)

--- a/skew.py
+++ b/skew.py
@@ -14,9 +14,9 @@ xygroup.add_argument(
     help='Error in the X-axis for the XY pair in mm.'
 )
 xygroup.add_argument(
-    '--xytan',
+    '--xyskew',
     type=float,
-    help='The error in the XY pair as a tangent. (xyerr/xylen)'
+    help='The skew factor, aka error in the XY pair (xyerr/xylen)'
 )
 
 
@@ -27,9 +27,9 @@ yzgroup.add_argument(
     help='Error in the Y-axis for the YZ pair in mm.'
 )
 yzgroup.add_argument(
-    '--yztan',
+    '--yzskew',
     type=float,
-    help='The error in the YZ pair as a tangent. (yzerr/yzlen)'
+    help='The skew factor, aka error in the yz pair (yzerr/yzlen).'
 )
 
 
@@ -40,9 +40,9 @@ zxgroup.add_argument(
     help='Error in the Z-axis for the ZX pair in mm.'
 )
 zxgroup.add_argument(
-    '--zxtan',
+    '--zxskew',
     type=float,
-    help='The error in the ZX pair as a tangent. (zxerr/zxlen)'
+    help='The skew factor, aka error in the ZX pair (zxerr/zxlen).'
 )
 
 
@@ -84,37 +84,37 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-if args.xytan:
-    xytan = args.xytan
+if args.xyskew:
+    xyskew = args.xyskew
 elif args.xyerr:
-    xytan = args.xyerr / args.xylen
+    xyskew = args.xyerr / args.xylen
 else:
-    xytan = 0.0
+    xyskew = 0.0
 
-if not xytan == 0:
-    print('The XY error is set to', xytan, 'degrees')
+if not xyskew == 0:
+    print('The XY error is set to', xyskew)
 
-if args.yztan:
-    yztan = args.yztan
+if args.yzskew:
+    yzskew = args.yzskew
 elif args.yzerr:
-    yztan = args.yzerr / args.yzlen
+    yzskew = args.yzerr / args.yzlen
 else:
-    yztan = 0.0
+    yzskew = 0.0
 
-if not yztan == 0:
-    print('The YZ error is set to', yztan, 'degrees')
+if not yzskew == 0:
+    print('The YZ error is set to', yzskew)
 
-if args.zxtan:
-    zxtan = args.zxtan
+if args.zxskew:
+    zxskew = args.zxskew
 elif args.zxerr:
-    zxtan = args.zxerr / args.zxlen
+    zxskew = args.zxerr / args.zxlen
 else:
-    zxtan = 0.0
+    zxskew = 0.0
 
-if not zxtan == 0:
-    print('The ZX error is set to', zxtan, 'degrees')
+if not zxskew == 0:
+    print('The ZX error is set to', zxskew)
 
-if xytan == 0.0 and yztan == 0.0 and zxtan == 0.0:
+if xyskew == 0.0 and yzskew == 0.0 and zxskew == 0.0:
     print('No skew parameters provided. Nothing will be done.')
 
 filename = args.file
@@ -156,9 +156,9 @@ with open(outname, 'a') as outfile:
                     zin = float(re.sub(r'[zZ]', '', zsrch.group()))
 
                 # calculate the corrected/skewed XYZ coordinates
-                xout = round(xin - yin * xytan, 3)
-                yout = round(yin - zin * yztan, 3)
-                xout = round(xout - zin * zxtan, 3)
+                xout = round(xin - yin * xyskew, 3)
+                yout = round(yin - zin * yzskew, 3)
+                xout = round(xout - zin * zxskew, 3)
                 # Z coodinates must remain the same to prevent layers being tilted!
                 zout = zin
 

--- a/skew.py
+++ b/skew.py
@@ -121,7 +121,7 @@ if xyskew == 0.0 and yzskew == 0.0 and xzskew == 0.0:
 
 filename = args.file
 
-outname = re.sub(r'.gcode', '-skewed.gcode', filename)
+outname = re.sub(r'.gcode', f'-gskewer-xy{xyskew},xz{xzskew},yz{yzskew}.gcode', filename)
 
 xin = 0.0
 yin = 0.0

--- a/skew.py
+++ b/skew.py
@@ -68,7 +68,12 @@ parser.add_argument(
 # input file setup. name of input file is not in "args.file"
 parser.add_argument("file", type=str)
 
-# parser.add_argument('-v', action='count', help='Increases terminal output verbosity. More V's will increase verbosity' )
+parser.add_argument(
+    '-v',
+    '--verbose',
+    action='count',
+     help='Increases terminal output verbosity.'
+)
 
 args = parser.parse_args()
 
@@ -123,7 +128,8 @@ with open(filename, 'r') as infile:
         # Check that the current 'line' is a move, if so the line is processed
         gmatch = re.match(r'G[0-1]', line, re.I)
         if gmatch:
-            print('line was a G0/G1 command!')
+            if args.verbose:
+                print('line was a G0/G1 command!')
 
             # load the incoming X coordinate into a variable. Previous value will be used if new value is not found.
             xsrch = re.search(r'[xX]-?\d*\.*\d*', line, re.I)
@@ -151,7 +157,8 @@ with open(filename, 'r') as infile:
             zout = zin
 
             lineout = line
-            print('old line:', lineout)
+            if args.verbose:
+                print('old line:', lineout)
 
             if xsrch:
                 lineout = re.sub(r'[xX]-?\d*\.*\d*', 'X' + str(xout), lineout)
@@ -162,8 +169,10 @@ with open(filename, 'r') as infile:
             if zsrch:
                 lineout = re.sub(r'[zZ]-?\d*\.*\d*', 'Z' + str(zout), lineout)
 
-            print('new line: ', lineout)
+            if args.verbose:
+                print('new line: ', lineout)
             outfile.write(lineout)
         else:
-            print('Skipping, not a movement.', line)
+            if args.verbose:
+                print('Skipping, not a movement.', line)
             outfile.write(line)

--- a/skew.py
+++ b/skew.py
@@ -65,6 +65,21 @@ parser.add_argument(
     help='Length of the side where the XZ error measurement was taken. This is optional, default value is 100mm'
 )
 
+
+parser.add_argument(
+    '--xscale',
+    default=100.0,
+    type=float,
+    help='Shrink or expand X axis. This is optional, default value is 100.0'
+)
+
+parser.add_argument(
+    '--yscale',
+    default=100.0,
+    type=float,
+    help='Shrink or expand Y axis. This is optional, default value is 100.0'
+)
+
 # input file setup. name of input file is not in "args.file"
 parser.add_argument("file", type=str)
 
@@ -114,14 +129,19 @@ else:
 if not yzskew == 0:
     print('The YZ skew is set to', yzskew)
 
+xscale = args.xscale
+yscale = args.yscale
+print(f"X scale: {xscale}")
+print(f"Y scale: {yscale}")
 
 if xyskew == 0.0 and yzskew == 0.0 and xzskew == 0.0:
-    print('No skew parameters provided. Nothing will be done.')
-    exit(0)
+    print('No skew parameters provided.')
+elif xscale == 100.0 and yscale == 100.0:
+    print("No scale arguments provided")
 
 filename = args.file
 
-outname = re.sub(r'.gcode', f'-gskewer-xy{xyskew},xz{xzskew},yz{yzskew}.gcode', filename)
+outname = re.sub(r'.gcode', f'-gskewer-xy{xyskew},xz{xzskew},yz{yzskew},x{xscale},y{yscale}.gcode', filename)
 
 xin = 0.0
 yin = 0.0
@@ -158,9 +178,9 @@ with open(outname, 'a') as outfile:
                     zin = float(re.sub(r'[zZ]', '', zsrch.group()))
 
                 # calculate the corrected/skewed XYZ coordinates
-                xout = round(xin - yin * xyskew, 3)
-                yout = round(yin - zin * yzskew, 3)
-                xout = round(xout - zin * xzskew, 3)
+                xout = round((xin - yin * xyskew), 3)
+                yout = round((yin * yscale / 100) - (zin * yzskew), 3)
+                xout = round((xout  * xscale / 100) - (zin * xzskew), 3)
                 # Z coodinates must remain the same to prevent layers being tilted!
                 zout = zin
 


### PR DESCRIPTION
I added --verbose, --overwrite flags, changed word use of tan to skew as it more accurately reflects the underlying math.

These changes should allow gskewer to be used to correct for skew as a slicer post processing script. I also updated the skew names to correspond to the names used by Marlin: https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/b91eeda0c16a9931126ea065f2fa2bcc8a983b8d/include/marlin/Configuration_MK3.5.h#L1270

Most commits are self contained and should be easy to follow, while reading the whole PR may be more involved.